### PR TITLE
Register change for recovery after PVDD loss

### DIFF
--- a/include/max98389.h
+++ b/include/max98389.h
@@ -17,6 +17,7 @@ public:
     const uint16_t pcm_tx_en_register =         0x205F;
     const uint16_t amp_en_register =            0x209F;
     const uint16_t iv_data_en_register =        0x20A7;
+    const uint16_t auto_recovery_register =     0x210E;
     const uint16_t global_en_register =         0x210F;
 
     I2CMaster& master = Master;

--- a/src/max98389.cpp
+++ b/src/max98389.cpp
@@ -50,6 +50,12 @@ bool max98389::configure(){
         report_error("ERROR: Failed to write PCM Tx Enable.");
         return false;
     }
+
+    if(!amp.write(auto_recovery_register, (uint8_t) 0x01, false)){
+        report_error("ERROR: Failed to write to auto recovery.");
+        return false;
+    }
+
     if(!amp.write(amp_en_register, (uint8_t) 0x01, false)){
         report_error("ERROR: Failed to write Amp Enable.");
         return false;


### PR DESCRIPTION
This change means that the amp automatically recovers and re-enables once PVDD returns after being lost. 

Without this change, the amp wouldn't have any output unless it was powered before starting the Teensy code, and is lost every time PVDD is power-cycled while the teensy remains running.